### PR TITLE
tests: KATs for h1 and h2 on bn254 w/ Keccak256 

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -174,7 +174,7 @@ export function preprocessDecryptionKey(ciphertext: Ciphertext, decryptionKey: G
 
 // Concrete instantiation of H_1 that outputs a point on G1
 // H_1: \{0, 1\}^\ast \rightarrow G_1
-function hashIdentityToG1(identity: Uint8Array, opts: IbeOpts): ProjPointType<Fp>{
+export function hashIdentityToG1(identity: Uint8Array, opts: IbeOpts): ProjPointType<Fp>{
     const hasher = createHasher(bn254.G1.ProjectivePoint, mapToG1, {
         p: htfDefaultsG1.p,
         m: htfDefaultsG1.m,
@@ -188,7 +188,7 @@ function hashIdentityToG1(identity: Uint8Array, opts: IbeOpts): ProjPointType<Fp
 
 // Concrete instantiation of H_2 that outputs a uniformly random byte string of length n
 // H_2: G_T \rightarrow \{0, 1\}^\ell
-function hashToBytes(shared_key: GT, n: number, opts: IbeOpts): Uint8Array {
+export function hashToBytes(shared_key: GT, n: number, opts: IbeOpts): Uint8Array {
     // encode shared_key as BE(shared_key.c0.c0.c0) || BE(shared_key.c0.c0.c1) || BE(shared_key.c0.c1.c0) || ...
     if (opts.expand_fn == "xmd") {
         return expand_message_xmd(bn254.fields.Fp12.toBytes(shared_key), opts.dsts.H2, n, opts.hash)

--- a/test/ibe.test.ts
+++ b/test/ibe.test.ts
@@ -1,5 +1,8 @@
 import {describe, it, expect} from "@jest/globals"
 import {IBE} from "../src"
+import {hashIdentityToG1, hashToBytes, IbeOpts} from "../src/crypto"
+import {keccak_256} from "@noble/hashes/sha3"
+import {bn254} from "../src/bn254"
 
 describe("encryption", () => {
     const ibe = new IBE()
@@ -25,5 +28,59 @@ describe("encryption", () => {
         const incorrectDecryptionKey = ibe.createDecryptionKey(secretKey, ibe.createIdentity(Buffer.from("banana")))
 
         expect(() => ibe.decrypt(ciphertext, incorrectDecryptionKey)).toThrowError()
+    })
+})
+
+describe("ibe bn254 KATs", () => {
+    it("h1", async () => {
+        const OPTS: IbeOpts = {
+            hash: keccak_256,
+            k: 128,
+            expand_fn: 'xmd',
+            dsts: {
+                H1_G1: Buffer.from('TEST_IBE_BN254G1_XMD:KECCAK-256_SVDW_RO_H1_'),
+                H2: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H2_'),
+                H3: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H3_'),
+                H4: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H4_'),
+            }
+        }
+
+        let g1 = hashIdentityToG1(Buffer.from(""), OPTS)
+        expect(g1.x).toEqual(BigInt("3653173467790182248506061396572709101962704209335577284294737943301013580835"))
+        expect(g1.y).toEqual(BigInt("2746942348379889347830045590181038295853386711647916449093173473614869629216"))
+
+        g1 = hashIdentityToG1(Buffer.from("AAAA"), OPTS)
+        expect(g1.x).toEqual(BigInt("16321686657743529192052651493099263906314638256513471437877788171012494023490"))
+        expect(g1.y).toEqual(BigInt("1350849970859344403057974536687145189475558284863891842544885697009576643682"))
+
+        g1 = hashIdentityToG1(Buffer.from("UOOQHNXMOVXWJZYTFTJCVYZCIXBSPVQY"), OPTS)
+        expect(g1.x).toEqual(BigInt("8929120621272588982321893216115445711479984949242622726428064156435284450717"))
+        expect(g1.y).toEqual(BigInt("14990022920127397634122290672777445403200199610320581106924212874052592382108"))
+    })
+
+    it("h2", async () => {
+        const OPTS: IbeOpts = {
+            hash: keccak_256,
+            k: 128,
+            expand_fn: 'xmd',
+            dsts: {
+                H1_G1: Buffer.from('TEST_IBE_BN254G1_XMD:KECCAK-256_SVDW_RO_H1_'),
+                H2: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H2_'),
+                H3: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H3_'),
+                H4: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H4_'),
+            }
+        }
+
+        let gt = bn254.pairing(bn254.G1.ProjectivePoint.BASE, bn254.G2.ProjectivePoint.BASE)
+        let h2 = hashToBytes(gt, 32, OPTS)
+        expect(Buffer.from(h2)).toEqual(Buffer.from('ad886214af94515c0d08269799f69ef80ccd8f6f63ccc40bfcd6517c5b62510c', 'hex'))
+
+        gt = bn254.pairing(bn254.G1.ProjectivePoint.BASE.double(), bn254.G2.ProjectivePoint.BASE)
+        h2 = hashToBytes(gt, 32, OPTS)
+        expect(Buffer.from(h2)).toEqual(Buffer.from('80a06d11d632a76edf7c3b2772f8c4d9d72095295315977620d224b363c3c49c', 'hex'))
+
+        gt = bn254.pairing(bn254.G1.ProjectivePoint.BASE.double(), bn254.G2.ProjectivePoint.BASE.double())
+        h2 = hashToBytes(gt, 32, OPTS)
+        expect(Buffer.from(h2)).toEqual(Buffer.from('39dc28417110a63f330a0dca9ff58bb936cfcb70407c875f5a114a56488112f5', 'hex'))
     })
 })

--- a/test/ibe.test.ts
+++ b/test/ibe.test.ts
@@ -45,12 +45,12 @@ describe("ibe bn254 KATs", () => {
         const OPTS: IbeOpts = {
             hash: keccak_256,
             k: 128,
-            expand_fn: 'xmd',
+            expand_fn: "xmd",
             dsts: {
-                H1_G1: Buffer.from('TEST_IBE_BN254G1_XMD:KECCAK-256_SVDW_RO_H1_'),
-                H2: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H2_'),
-                H3: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H3_'),
-                H4: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H4_'),
+                H1_G1: Buffer.from("TEST_IBE_BN254G1_XMD:KECCAK-256_SVDW_RO_H1_"),
+                H2: Buffer.from("TEST_IBE_BN254_XMD:KECCAK-256_H2_"),
+                H3: Buffer.from("TEST_IBE_BN254_XMD:KECCAK-256_H3_"),
+                H4: Buffer.from("TEST_IBE_BN254_XMD:KECCAK-256_H4_"),
             }
         }
 
@@ -71,26 +71,25 @@ describe("ibe bn254 KATs", () => {
         const OPTS: IbeOpts = {
             hash: keccak_256,
             k: 128,
-            expand_fn: 'xmd',
+            expand_fn: "xmd",
             dsts: {
-                H1_G1: Buffer.from('TEST_IBE_
-                                   G1_XMD:KECCAK-256_SVDW_RO_H1_'),
-                H2: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H2_'),
-                H3: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H3_'),
-                H4: Buffer.from('TEST_IBE_BN254_XMD:KECCAK-256_H4_'),
+                H1_G1: Buffer.from("TEST_IBE_ G1_XMD:KECCAK-256_SVDW_RO_H1_"),
+                H2: Buffer.from("TEST_IBE_BN254_XMD:KECCAK-256_H2_"),
+                H3: Buffer.from("TEST_IBE_BN254_XMD:KECCAK-256_H3_"),
+                H4: Buffer.from("TEST_IBE_BN254_XMD:KECCAK-256_H4_"),
             }
         }
 
         let gt = bn254.pairing(bn254.G1.ProjectivePoint.BASE, bn254.G2.ProjectivePoint.BASE)
         let h2 = hashToBytes(gt, 32, OPTS)
-        expect(Buffer.from(h2)).toEqual(Buffer.from('ad886214af94515c0d08269799f69ef80ccd8f6f63ccc40bfcd6517c5b62510c', 'hex'))
+        expect(Buffer.from(h2)).toEqual(Buffer.from("ad886214af94515c0d08269799f69ef80ccd8f6f63ccc40bfcd6517c5b62510c", "hex"))
 
         gt = bn254.pairing(bn254.G1.ProjectivePoint.BASE.double(), bn254.G2.ProjectivePoint.BASE)
         h2 = hashToBytes(gt, 32, OPTS)
-        expect(Buffer.from(h2)).toEqual(Buffer.from('80a06d11d632a76edf7c3b2772f8c4d9d72095295315977620d224b363c3c49c', 'hex'))
+        expect(Buffer.from(h2)).toEqual(Buffer.from("80a06d11d632a76edf7c3b2772f8c4d9d72095295315977620d224b363c3c49c", "hex"))
 
         gt = bn254.pairing(bn254.G1.ProjectivePoint.BASE.double(), bn254.G2.ProjectivePoint.BASE.double())
         h2 = hashToBytes(gt, 32, OPTS)
-        expect(Buffer.from(h2)).toEqual(Buffer.from('39dc28417110a63f330a0dca9ff58bb936cfcb70407c875f5a114a56488112f5', 'hex'))
+        expect(Buffer.from(h2)).toEqual(Buffer.from("39dc28417110a63f330a0dca9ff58bb936cfcb70407c875f5a114a56488112f5", "hex"))
     })
 })


### PR DESCRIPTION
- KATs for h1 and h2 on bn254 w/ Keccak256 
- export `hashidentityToG1` and `hashToBytes` because it's apparently not possible to tests these functions otherwise :(